### PR TITLE
Fix GitHub Pages base path configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -12,6 +12,16 @@ This directory contains the Next.js frontend for the lung cancer risk prediction
 - `npm start` — run the production build with `next start`
 - `npm test` — run the ESLint suite (alias for `npm run lint`)
 
+## Deploying to GitHub Pages
+This project statically exports the site (`next.config.mjs` sets `output: 'export'`). When the
+build runs inside GitHub Actions we automatically derive the repository name from the
+`GITHUB_REPOSITORY` environment variable and configure the correct `basePath`/`assetPrefix`.
+This ensures the generated files are served from `https://<user>.github.io/<repo>/` instead of
+the domain root, which prevents the blank page/404 that otherwise appears on GitHub Pages.
+
+If you build locally and want to mimic the GitHub Pages output you can set
+`GITHUB_ACTIONS=true GITHUB_REPOSITORY=<owner>/<repo>` before running `npm run build`.
+
 ## Styling notes
 The default layout uses system UI fonts so the Docker image does not require network access for font downloads. Global styles live in [`app/globals.css`](app/globals.css) and the top-level layout is defined in [`app/layout.tsx`](app/layout.tsx).
 

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,9 +1,26 @@
 /**
  * @type {import('next').NextConfig}
  */
+
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+let assetPrefix;
+let basePath;
+
+if (isGithubActions) {
+  const repoName = process.env.GITHUB_REPOSITORY?.split('/')?.[1];
+
+  if (repoName) {
+    assetPrefix = `/${repoName}/`;
+    basePath = `/${repoName}`;
+  }
+}
+
 const nextConfig = {
   output: 'export',
   images: { unoptimized: true },
+  assetPrefix,
+  basePath,
+  trailingSlash: true,
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
## Summary
- derive the repository name during GitHub Actions builds to configure Next.js basePath and assetPrefix for static export
- enable trailing slashes so nested routes resolve on GitHub Pages
- document the GitHub Pages deployment workflow and required environment variables

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68e30f5cd04c832a8b3a2516c0a94000